### PR TITLE
Add card template for new fifth card

### DIFF
--- a/src/gen_notes.py
+++ b/src/gen_notes.py
@@ -50,7 +50,7 @@ def process_lines(text):
                 "last_letters": last_letters_removed,
                 "verse_number": current_verse,
                 "verse_part": letter,
-                "answer": line.strip(),
+                "answer": content,
 
             })
         subline_index += 1

--- a/src/model.py
+++ b/src/model.py
@@ -89,6 +89,9 @@ _card3_back = (
 )
 _card4_front = '<div id="card">\n<div>{{title}}</div>\n<div class="passage">{{verse_number}}{{verse_part}}</div>\n<br>\n<div class="front">{{front}}</div>\n</div>'
 _card4_back = '{{FrontSide}}\n<br>\n<hr id="answer">\n<div class="back">{{back}}</div>'
+# TODO: The front now contains the verse but also the verse number. A new field must be generated that includes the verse without the verse number
+_card5_front = '<div id="card">\n<div>{{answer}}</div>\n</div>'
+_card5_back = '{{FrontSide}}\n<br>\n<hr id="answer">\n<div class="back">\n<div>{{title}}</div>\n<div class="passage">{{verse_number}}{{verse_part}}</div>\n</div>\n'
 
 _current_version = "1.4"
 
@@ -119,6 +122,11 @@ def create_model(mw):
     t = mm.new_template("Card 4")
     t["qfmt"] = _card4_front
     t["afmt"] = _card4_back
+    mm.addTemplate(m, t)
+
+    t = mm.new_template("Card 5")
+    t["qfmt"] = _card5_front
+    t["afmt"] = _card5_back
     mm.addTemplate(m, t)
 
     mm.add(m)
@@ -217,6 +225,7 @@ def get_bm_model():
         upgradeonedotfour(mw, m)
         aqt.mw.col.set_config("bm_model_version", _current_version)
 
+    # TODO: Add upgrade for Card 5 template
 
     # Add new fields if they don't exist yet
     fields_to_add = [


### PR DESCRIPTION
I would like to suggest the option to generate a new card that aks the learner to recall from where a learned passage originates. The front would show a single verse without any number, the back would show the reference to the passage.

This is work in progress. I would like to hear your opinion on this idea and maybe discuss some options before completing this PR.

---

## Todos:

- [ ] Add field for verse without verse number (currently verse number is shown on the front template)
- [ ] Upgrade method to add the new template
- [ ] Optionally: Add checkbox to skip generation of this card
- [ ] Update documentation with screenshot of new card

...anything else?